### PR TITLE
fix!: warn instead of error on missing variables

### DIFF
--- a/envsubst/envsubst.go
+++ b/envsubst/envsubst.go
@@ -4,33 +4,15 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/drone/envsubst"
+	"github.com/drone/envsubst/v2"
 )
 
-type MissingVariableError struct {
-	Variable string
-}
-
-func (m MissingVariableError) Error() string {
-	return fmt.Sprintf("variable %q is not set", m.Variable)
-}
-
-// StrictEval is similar to Eval of github.com/drone/envsubst, but returns an error when a variable is missing.
+// StrictEval is similar to Eval of github.com/drone/envsubst, but logs a warning when a variable is missing.
 func StrictEval(in string, mapping func(string) string) (out string, err error) {
-	// Recover panics caused by missing variables.
-	defer func() {
-		rec := recover()
-		recErr, ok := rec.(MissingVariableError)
-		if ok {
-			out = ""
-			err = recErr
-		}
-	}()
-
 	out, err = envsubst.Eval(in, func(s string) string {
 		v := mapping(s)
 		if v == "" {
-			panic(MissingVariableError{Variable: s})
+			fmt.Fprintf(os.Stderr, "variable %q might be missing\n", s)
 		}
 
 		return v
@@ -39,7 +21,7 @@ func StrictEval(in string, mapping func(string) string) (out string, err error) 
 	return out, err
 }
 
-// StrictEvalEnv is similar to EvalEnv of github.com/drone/envsubst, but returns an error when a variable is missing.
+// StrictEvalEnv is similar to EvalEnv of github.com/drone/envsubst, but logs a warning when a variable is missing.
 func StrictEvalEnv(s string) (string, error) {
 	return StrictEval(s, os.Getenv)
 }

--- a/envsubst/envsubst_test.go
+++ b/envsubst/envsubst_test.go
@@ -13,8 +13,8 @@ func TestStrictEvalMissingVariable(t *testing.T) {
 		return ""
 	})
 
-	assert.EqualError(t, err, "variable \"foo\" is not set")
-	assert.Equal(t, "", out)
+	assert.NoError(t, err)
+	assert.Equal(t, "Hello !", out)
 }
 
 func TestStrictEval(t *testing.T) {
@@ -29,8 +29,15 @@ func TestStrictEval(t *testing.T) {
 func TestStrictEvalEnvMissingVariable(t *testing.T) {
 	out, err := StrictEvalEnv("Hello ${foo}!")
 
-	assert.EqualError(t, err, "variable \"foo\" is not set")
-	assert.Equal(t, "", out)
+	assert.NoError(t, err)
+	assert.Equal(t, "Hello !", out)
+}
+
+func TestStrictEvalEnvMissingVariableWithDefault(t *testing.T) {
+	out, err := StrictEvalEnv("Hello ${foo:=bar}!")
+
+	assert.NoError(t, err)
+	assert.Equal(t, "Hello bar!", out)
 }
 
 func TestStrictEvalEnv(t *testing.T) {

--- a/envsubst/kustomize_test.go
+++ b/envsubst/kustomize_test.go
@@ -34,8 +34,43 @@ func TestSubstituteVariables_MissingVariable(t *testing.T) {
 	err := yaml.Unmarshal(raw, res)
 	assert.NoError(t, err)
 
-	_, err = SubstituteVariables(context.TODO(), res)
-	assert.EqualError(t, err, "variable substitution failed for  /: variable \"foo\" is not set")
+	out, err := SubstituteVariables(context.TODO(), res)
+	assert.NoError(t, err)
+
+	rawOut, err := out.AsYAML()
+	assert.NoError(t, err)
+	assert.Equal(t, "foo: null\n", string(rawOut))
+}
+
+func TestSubstituteVariables_WithDefault(t *testing.T) {
+	reset := tmpEnv("foo", "bar")
+	defer reset()
+
+	raw := []byte("foo: ${foo:-baz}")
+	res := &resource.Resource{}
+	err := yaml.Unmarshal(raw, res)
+	assert.NoError(t, err)
+
+	out, err := SubstituteVariables(context.TODO(), res)
+	assert.NoError(t, err)
+
+	rawOut, err := out.AsYAML()
+	assert.NoError(t, err)
+	assert.Equal(t, "foo: bar\n", string(rawOut))
+}
+
+func TestSubstituteVariables_MissingVariableWithDefault(t *testing.T) {
+	raw := []byte("foo: ${foo:-bar}")
+	res := &resource.Resource{}
+	err := yaml.Unmarshal(raw, res)
+	assert.NoError(t, err)
+
+	out, err := SubstituteVariables(context.TODO(), res)
+	assert.NoError(t, err)
+
+	rawOut, err := out.AsYAML()
+	assert.NoError(t, err)
+	assert.Equal(t, "foo: bar\n", string(rawOut))
 }
 
 func TestSubstituteVariablesAnnotation(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/jaconi-io/flux-envsubst
 go 1.18
 
 require (
-	github.com/drone/envsubst v1.0.3
+	github.com/drone/envsubst/v2 v2.0.0-20210730161058-179042472c46
 	github.com/joho/godotenv v1.4.0
 	github.com/spf13/cobra v1.6.1
 	github.com/spf13/viper v1.14.0

--- a/go.sum
+++ b/go.sum
@@ -58,8 +58,8 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815/go.mod h1:WwZ+bS3ebgob9U8Nd0kOddGdZWjyMGR8Wziv+TBNwSE=
-github.com/drone/envsubst v1.0.3 h1:PCIBwNDYjs50AsLZPYdfhSATKaRg/FJmDc2D6+C2x8g=
-github.com/drone/envsubst v1.0.3/go.mod h1:N2jZmlMufstn1KEqvbHjw40h1KyTmnVzHcSc9bFiJ2g=
+github.com/drone/envsubst/v2 v2.0.0-20210730161058-179042472c46 h1:7QPwrLT79GlD5sizHf27aoY2RTvw62mO6x7mxkScNk0=
+github.com/drone/envsubst/v2 v2.0.0-20210730161058-179042472c46/go.mod h1:esf2rsHFNlZlxsqsZDojNBcnNs5REqIvRrWRHqX0vEU=
 github.com/emicklei/go-restful v0.0.0-20170410110728-ff4f55a20633/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=


### PR DESCRIPTION
Previously, errors prevented envsubst defaulting logic to kick in. We now use warnings instead.

Closes #19