### PR TITLE
fix: update major version in compliance with go standards

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -3,7 +3,7 @@ package cmd
 import (
 	"fmt"
 
-	"github.com/jaconi-io/flux-envsubst/v3/envsubst"
+	"github.com/jaconi-io/flux-envsubst/v4/envsubst"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"

--- a/envsubst/envsubst_test.go
+++ b/envsubst/envsubst_test.go
@@ -3,7 +3,7 @@ package envsubst_test
 import (
 	"testing"
 
-	. "github.com/jaconi-io/flux-envsubst/v3/envsubst"
+	. "github.com/jaconi-io/flux-envsubst/v4/envsubst"
 
 	"github.com/stretchr/testify/assert"
 )

--- a/envsubst/kustomize_test.go
+++ b/envsubst/kustomize_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"testing"
 
-	. "github.com/jaconi-io/flux-envsubst/v3/envsubst"
+	. "github.com/jaconi-io/flux-envsubst/v4/envsubst"
 	"sigs.k8s.io/kustomize/api/resource"
 	"sigs.k8s.io/yaml"
 

--- a/envsubst/yaml_test.go
+++ b/envsubst/yaml_test.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 	"testing"
 
-	. "github.com/jaconi-io/flux-envsubst/v3/envsubst"
+	. "github.com/jaconi-io/flux-envsubst/v4/envsubst"
 
 	"github.com/stretchr/testify/assert"
 )

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/jaconi-io/flux-envsubst/v3
+module github.com/jaconi-io/flux-envsubst/v4
 
 go 1.21
 

--- a/main.go
+++ b/main.go
@@ -1,6 +1,6 @@
 package main
 
-import "github.com/jaconi-io/flux-envsubst/v3/cmd"
+import "github.com/jaconi-io/flux-envsubst/v4/cmd"
 
 func main() {
 	cmd.Execute()


### PR DESCRIPTION
BREAKING CHANGE: The module path contains 'v4' now.